### PR TITLE
Updates

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Disable the ordered update function.
     required: false
     default: 'false'
+  enable_concurrent:
+    description: Enable concurrent execution of commands.
+    required: false
+    default: 'true'
 outputs:
   output:
     description: The output of the dnscontrol command that was executed.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ CREDS_ABS_PATH="$(readlink -f "${INPUT_CREDS_FILE}")"
 ALLOW_FETCH="${ALLOW_FETCH:-false}"
 DISABLE_ORDERED_UPDATE="${DISABLE_ORDERED_UPDATE:-false}"
 ENABLE_COLORS="${ENABLE_COLORS:-false}"
+ENABLE_CONCURRENT="${ENABLE_CONCURRENT:-true}"
 
 WORKING_DIR="$(dirname "${CONFIG_ABS_PATH}")"
 cd "$WORKING_DIR" || exit
@@ -23,6 +24,12 @@ fi
 
 if [ "$ALLOW_FETCH" = true ]; then
   ARGS+=(--allow-fetch)
+fi
+
+if [ "$ENABLE_CONCURRENT" = true ]; then
+  ARGS+=(--cmode=concurrent)
+else
+  ARGS+=(--cmode=legacy)
 fi
 
 ARGS+=(


### PR DESCRIPTION
This pull request includes updates to the `dnscontrol-action` to enable concurrent execution of commands and update the Docker image version. The most important changes are the addition of a new input parameter for enabling concurrency and the corresponding logic in the entrypoint script.

Enhancements:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R32-R42): Added a new input parameter `enable_concurrent` to allow enabling concurrent execution of commands. The default value is set to 'true'.
* [`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R11): Introduced a new environment variable `ENABLE_CONCURRENT` to read the value of the `enable_concurrent` input parameter.

Docker Image Update:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R32-R42): Updated the Docker image version from `v4.13.0` to `v4.14.0`.

Concurrency Logic:

* [`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R29-R34): Added logic to handle the `ENABLE_CONCURRENT` parameter, appending the appropriate command mode (`--cmode=concurrent` or `--cmode=legacy`) to the arguments list based on its value.