### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,4 +39,4 @@ outputs:
 runs:
   using: docker
   # image: 'Dockerfile'
-  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.14.3'
+  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.15.1'


### PR DESCRIPTION
This pull request includes an update to the Docker image version in the `action.yml` file. The change updates the image from version `v4.14.3` to `v4.15.1`.

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L42-R42): Updated Docker image from `ghcr.io/jniklas2/dnscontrol-action:v4.14.3` to `ghcr.io/jniklas2/dnscontrol-action:v4.15.1`.