### PR TITLE
Update and rename renovate.json to .github/renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    "group:allNonMajor"
+  ],
+  "forkProcessing": "enabled",
+  "ignoreUnstable": "true",
+  "respectLatest": "true",
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "assignees": ["@Jniklas2"]
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,0 @@
-{
-  "extends": [
-    "config:recommended",
-    ":dependencyDashboard",
-    "group:allNonMajor"
-  ],
-  "forkProcessing": "enabled"
-}


### PR DESCRIPTION
This pull request involves updating the Renovate configuration to enhance dependency management and security alert handling. The most important changes include migrating the configuration to `.github/renovate.json` and adding new settings for ignoring unstable dependencies and respecting the latest versions.

Changes to Renovate configuration:

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3R1-R14): Migrated the Renovate configuration to this file and added new settings for ignoring unstable dependencies and respecting the latest versions. Also included settings for vulnerability alerts with specific labels and assignees.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L1-L8): Removed the old Renovate configuration file as its settings have been migrated and expanded in `.github/renovate.json`.