### PR TITLE
Update dnscontrol image and documentation links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v4.0.0
+        uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v7.0.0
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/stackexchange/dnscontrol:4.36.1@sha256:6863844d713b1ead915d02aedf04d0ea16cdbdc1b09d48982bdee777526f9be1
+FROM ghcr.io/dnscontrol/dnscontrol:4.37.1@sha256:2e285aeb9937e973435bd733ccf30b96cf4650144e6d5443c6caa72bb4c0495d
 
 LABEL repository="https://github.com/Jniklas2/DNSControl-Action"
 LABEL maintainer="Jniklas2 <github@sl.crcr.tech>"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![](https://github.com/Jniklas2/DNSControl-Action/workflows/build/badge.svg)
 
 Deploy your DNS configuration using [GitHub Actions](https://github.com/actions)
-using [DNSControl](https://github.com/StackExchange/dnscontrol/).
+using [DNSControl](https://github.com/DNSControl/dnscontrol/).
 
 ## Usage
 
@@ -153,7 +153,7 @@ be set. These secrets can be configured through a file named `creds.json`. You
 should **not** add secrets as plaintext to this file, but use GitHub
 Actions [encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
 instead. These encrypted secrets are exposed at runtime as environment variables.
-See the DNSControl [Service Providers](https://stackexchange.github.io/dnscontrol/provider-list)
+See the DNSControl [Service Providers](https://docs.dnscontrol.org/provider/index)
 documentation for details.
 
 To follow the Cloudflare example, add an encrypted secret named `CLOUDFLARE_API_TOKEN`

--- a/action.yml
+++ b/action.yml
@@ -39,4 +39,4 @@ outputs:
 runs:
   using: docker
   # image: 'Dockerfile'
-  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.36.1'
+  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.37.1'


### PR DESCRIPTION
This pull request updates the project to use the latest upstream DNSControl container image and updates documentation to reflect the new upstream repository and documentation URLs. The most important changes are:

**Dependency and Image Updates:**

* Updated the `Dockerfile` to use the official `ghcr.io/dnscontrol/dnscontrol:4.37.1` image instead of the previous `ghcr.io/stackexchange/dnscontrol:4.36.1` image.

**Documentation Updates:**

* Updated the `README.md` to reference the new DNSControl GitHub repository (`github.com/DNSControl/dnscontrol`) instead of the old StackExchange repository.
* Changed the Service Providers documentation link in `README.md` to point to the new DNSControl documentation site (`docs.dnscontrol.org`) instead of the old StackExchange GitHub Pages site.