### PR TITLE
Update Docker image version to v4.42.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,4 +39,4 @@ outputs:
 runs:
   using: docker
   # image: 'Dockerfile'
-  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.41.0'
+  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.42.0'


### PR DESCRIPTION
This pull request updates the Docker image version used in the GitHub Action configuration to ensure the workflow uses the latest features and fixes.

Dependency update:

* Updated the Docker image in `action.yml` from version `v4.41.0` to `v4.42.0` to use the latest release of `dnscontrol-action`.