### PR TITLE
Update DNSControl to v4.43.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/dnscontrol/dnscontrol:4.42.0@sha256:abe1d1d57d0f83f4e651a6eb4430b64e7bfd1433918aa7f4bca7bfa4be92d62e
+FROM ghcr.io/dnscontrol/dnscontrol:4.43.2@sha256:401a8f8d5b18b25c202c32a0e23a28e562b69b5cab286ff134b2b335eaee2c7b
 
 LABEL repository="https://github.com/Jniklas2/DNSControl-Action"
 LABEL maintainer="Jniklas2 <github@sl.crcr.tech>"

--- a/action.yml
+++ b/action.yml
@@ -39,4 +39,4 @@ outputs:
 runs:
   using: docker
   # image: 'Dockerfile'
-  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.42.0'
+  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.43.2'


### PR DESCRIPTION
Update DNSControl base image from v4.42.0 to v4.43.2 in both Dockerfile and action.yml. Includes updated SHA256 digest for the Docker image.