### PR TITLE
Update Docker image version to v4.44.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,4 +39,4 @@ outputs:
 runs:
   using: docker
   # image: 'Dockerfile'
-  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.43.2'
+  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.44.1'


### PR DESCRIPTION
This pull request updates the Docker image version used in the GitHub Action configuration to ensure the workflow uses the latest features and bug fixes.

* Updated the Docker image in `action.yml` from `dnscontrol-action:v4.43.2` to `dnscontrol-action:v4.44.1`, ensuring the action runs with the latest version.