### PR TITLE
Update Docker image version to v4.46.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,4 +39,4 @@ outputs:
 runs:
   using: docker
   # image: 'Dockerfile'
-  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.45.0'
+  image: 'docker://ghcr.io/jniklas2/dnscontrol-action:v4.46.0'


### PR DESCRIPTION
This pull request updates the DNSControl Docker image version used by the GitHub Action to ensure the latest features and fixes are included.

* Updated the Docker image in `action.yml` from version `v4.45.0` to `v4.46.0` to use the latest DNSControl release.